### PR TITLE
SDKF-2515 Implement Initial Report Methods (Page Events, Cart Data, A…

### DIFF
--- a/monetate/core/Personalization.swift
+++ b/monetate/core/Personalization.swift
@@ -314,6 +314,40 @@ public class Personalization {
     }
 }
 
+// MARK: - New individual Report methodes
+extension Personalization {
+    /**
+     * Used to report PageEvents data
+     * - Parameter contextData: Context object that contains the PageEvents data
+     */
+    public func reportPageEvents(contextData: ContextObj) {
+        let pageEventsData = contextData.getPageEventsData()
+        report(context: .PageEvents, event: pageEventsData)
+    }
+    
+    /**
+     * Used to report Cart data
+     * - Parameter contextData: Context object  that contains the Cart data
+     */
+    public func reportCartData(contextData: ContextObj) {
+        let cartLines = contextData.getAllCartData()
+        let cart = Cart(cartLines: cartLines)
+        report(context: .Cart, event: cart)
+    }
+    
+    /**
+     * Used to report Single Cart data
+     * - Parameter contextData: Context object  that contains the AddToCart data
+     */
+    public func reportAddToCartData(contextData: ContextObj) {
+        if let cartLine = contextData.getSingleCartData() {
+            let cartLines = [cartLine]
+            let addToCart = AddToCart(cartLines: cartLines)
+            report(context: .AddToCart, event: addToCart)
+        }
+    }
+}
+
 extension Date {
     func toMillis() -> Int64! {
         return Int64(self.timeIntervalSince1970 * 1000)


### PR DESCRIPTION

**Why** 
https://monetate.atlassian.net/browse/SDKF-2515

**How** 
Added individual report methods for Page Events, Cart Data, Add to Cart Data in iOS SDK

**Before** 
No individual report methods in Personalization class for following events:

1. reportPageEvents(Context context)
2. reportCartData(Context context)
3. reportAddToCartData(Context context)


**After** 
Added individual report methods in Personalization class for following events:

1. reportPageEvents(Context context)
2. reportCartData(Context context)
3. reportAddToCartData(Context context)