### PR TITLE
SDKF-2517 Implement Final Report Methods for Impressions and Clicks

### DIFF
--- a/monetate/core/Personalization.swift
+++ b/monetate/core/Personalization.swift
@@ -374,6 +374,42 @@ extension Personalization {
         report(context: .ProductDetailView, event: productDetailView)
     }
     
+    /**
+     Used to report ProductThumbnailData
+     - Parameter contextData: Context object that contains the ProductThumbnailData
+     */
+    public func reportProductThumbnailData(contextData: ContextObj) {
+        let productThumbnailView = contextData.getProductThumbnailsData()
+        report(context: .ProductThumbnailView, event: productThumbnailView)
+    }
+
+    /**
+     Used to report Impressions data
+     - Parameter ids: An array of id Strings to be processed
+     */
+    public func reportImpressionsData(ids: [String]) {
+        let impressions = Impressions(impressionIds: ids)
+        report(context: .Impressions, event: impressions)
+    }
+
+    /**
+     Used to report RecImpressions data
+     - Parameter tokens: An array of token Strings to be processed
+     */
+    public func reportRecImpressionsData(tokens: [String]) {
+        let recImpressions = RecImpressions(recImpressions: tokens)
+        report(context: .RecImpressions, event: recImpressions)
+    }
+
+    /**
+     Used to report RecClicks data
+     - Parameter tokens: An array of token Strings to be processed
+     */
+    public func reportRecClicksData(tokens: [String]) {
+        let recClicks = RecClicks(recClicks: tokens)
+        report(context: .RecClicks, event: recClicks)
+    }
+    
 }
 
 extension Date {


### PR DESCRIPTION
**Why** 
https://monetate.atlassian.net/browse/SDKF-2517

**How **
Added individual report methods for specific events in iOS SDK

**Before**
No individual report method's for following events in personalization class.

reportProductThumbnailViewData(Context context)
reportImpressionsData(String[] ids)
reportRecImpressions(String[] tokens)
reportRecClicks(String[] tokens)

**After**
Added individual report method's for following events in personalization class.

reportProductThumbnailViewData(Context context)
reportImpressionsData(String[] ids)
reportRecImpressions(String[] tokens)
reportRecClicks(String[] tokens)