### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "Monetate",
+    platforms: [
+        .iOS(.v13),
+    ],
+    products: [
+        .library(name: "Monetate", targets: ["Monetate"])
+    ],
+    targets: [
+        .target(name: "Monetate", path: "monetate")
+    ],
+    swiftLanguageVersions: [
+        .version("5")
+    ]
+)


### PR DESCRIPTION
### Context

With CocoaPods [entering maintenance mode](https://blog.cocoapods.org/CocoaPods-Specs-Repo/) and SPM progressively gaining adoption, I believe there's added value in also providing the Monetate iOS SDK through SPM.

### Changes

- Add `Package.swift` to allow library to be imported through SPM

Note that `import monetate_ios_sdk` now becomes `import Monetate` which better aligns with system imports.